### PR TITLE
Use the published binary HTTP version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-MD_PREPROCESSOR := sed -e 's/{::date}/'"$$(git log -n 1 --date=short --format='%ad' @)"'/g'
-
 LIBDIR := lib
 include $(LIBDIR)/main.mk
 

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -30,17 +30,7 @@ author:
 
 normative:
 
-  BINARY:
-    title: "Binary Representation of HTTP Messages"
-    date: {::date}
-    seriesinfo:
-      Internet-Draft: draft-thomson-http-binary-message-latest
-    author:
-      -
-        ins: M.Thomson
-        name: Martin Thomson
-        org: Mozilla
-
+  BINARY: I-D.ietf-httpbis-binary-message
   HTTP: I-D.ietf-httpbis-semantics
   QUIC: RFC9000
   TLS: RFC8446


### PR DESCRIPTION
This makes the whole `{::date}` thing unnecessary as well.