### PR TITLE
Anti-replay mechanism

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1114,6 +1114,10 @@ client, with a time window that is large enough to allow for differences in the
 clock of clients and servers.  How large a time window is needed could depend on
 the population of clients that the server needs to serve.
 
+Servers MUST NOT treat the time window as secret information. An attacker can
+actively probe the server with specially crafted request timestamps to determine
+the time window over which the server will accept responses.
+
 {{?REQUEST-DATE=I-D.thomson-httpapi-request-date}} contains further
 considerations for the use of the `Date` request header field.  This includes
 the way in which clients might correct for clock skew and the privacy

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1088,10 +1088,6 @@ server. The use of idempotent methods might be of some use in managing replay
 risk, though it is important to recognize that different idempotent requests
 can be combined to be not idempotent.
 
-Idempotent actions with a narrow scope based on the value of an
-application-provided nonce could enable data submission with limited replay
-protection.
-
 Even without strong replay prevention, the server-chosen `response_nonce` field
 ensures that responses have unique AEAD keys and nonces even when requests are
 replayed.

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1108,15 +1108,18 @@ A server can maintain state for requests for a small window of time over which
 it wishes to accept requests.  The server then rejects requests if the request
 is the same as one that was previously answered within that time window.
 Servers can identify duplicate requests using the `enc` value.  The server can
-reject requests if the Date request header ffield is outside of the chosen time
+reject requests if the Date request header field is outside of the chosen time
 window.  Servers SHOULD allow for the time it takes requests to arrive from the
 client, with a time window that is large enough to allow for differences in the
 clock of clients and servers.  How large a time window is needed could depend on
 the population of clients that the server needs to serve.
 
 {{?REQUEST-DATE=I-D.thomson-httpapi-request-date}} contains further
-considerations for the use of dates.  This includes the way in which clients might
-correct for clock skew and the privacy considerations arising from that usage.
+considerations for the use of the `Date` request header field.  This includes
+the way in which clients might correct for clock skew and the privacy
+considerations arising from that usage.  Servers that reject requests on the
+basis of the `Date` request header field SHOULD implement the feedback mechanism
+in {{Section 4 of !REQUEST-DATE}} to support clock correction by clients.
 
 
 ## Post-Compromise Security


### PR DESCRIPTION
This recommends the use of `Date` in requests as discussed on #88 and #76.

Most of the heavy lifting is outsourced to [a new draft](https://datatracker.ietf.org/doc/draft-thomson-httpapi-date-requests/), so I won't merge this until we have some greater certainty about the destiny of that draft.

Closes #76.
Closes #89.