### PR TITLE
Elaborate on the fixed mapping between proxy and request resources

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -182,7 +182,9 @@ A client learns the following:
   used with that key.
 
 * The identity of an oblivious proxy resource that will forward encapsulated
-  requests and responses to the oblivious request resource.
+  requests and responses to a single oblivious request resource. See {{proxy-state}}
+  for more information about the mapping between oblivious proxy and oblivious
+  request resources.
 
 This information allows the client to make a request of an oblivious target
 resource without that resource having only a limited ability to correlate that
@@ -1120,11 +1122,34 @@ for ensuring the key configurations are consistent between different clients.
 
 # Operational and Deployment Considerations {#deployment}
 
+This section discusses various operational and deployment considerations.
+
+## Performance Overhead
+
 Using Oblivious HTTP adds both cryptographic and latency to requests relative to
 a simple HTTP request-response exchange.  Deploying proxy services that are on
 path between clients and servers avoids adding significant additional delay due
 to network topology.  A study of a similar system {{ODoH}} found that deploying
 proxies close to servers was most effective in minimizing additional latency.
+
+
+## Oblivious Proxy State {#proxy-state}
+
+The Oblivious Proxy Resource is a fixed mapping between URI and the Oblivious
+Request Resource. This means that any encapsulated request sent to the Oblivious
+Proxy Resource will always be forwarded to the Oblivious Request Resource.
+This constraint was imposed to simplify proxy configuration and mitigate against
+the Oblivious Proxy Resource being used as a generic proxy for unknown Oblivious
+Request Resources. The proxy will only forward for Oblivious Request Resources
+that it has explicitly configured and allowed.
+
+It is possible for an Oblivious Proxy to be configured with multiple Oblivious
+Proxy Resources, each for a different Oblivious Request Resource as needed.
+As a consequence, the amount of state required for these mappings is linear
+in the number of Oblivious Proxy Resources supported.
+
+
+## Network Management
 
 Oblivious HTTP might be incompatible with network interception regimes, such as
 those that rely on configuring clients with trust anchors and intercepting TLS

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1135,8 +1135,8 @@ proxies close to servers was most effective in minimizing additional latency.
 
 ## Resource Mappings {#proxy-state}
 
-The Oblivious Proxy Resource is a fixed mapping between URI and the Oblivious
-Request Resource. This means that any encapsulated request sent to the Oblivious
+This protocol assumes a fixed, one-to-one mapping between the Oblivious Proxy Resource and 
+the Oblivious Request Resource. This means that any encapsulated request sent to the Oblivious
 Proxy Resource will always be forwarded to the Oblivious Request Resource.
 This constraint was imposed to simplify proxy configuration and mitigate against
 the Oblivious Proxy Resource being used as a generic proxy for unknown Oblivious

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1135,13 +1135,14 @@ proxies close to servers was most effective in minimizing additional latency.
 
 ## Resource Mappings {#proxy-state}
 
-This protocol assumes a fixed, one-to-one mapping between the Oblivious Proxy Resource and 
-the Oblivious Request Resource. This means that any encapsulated request sent to the Oblivious
-Proxy Resource will always be forwarded to the Oblivious Request Resource.
-This constraint was imposed to simplify proxy configuration and mitigate against
-the Oblivious Proxy Resource being used as a generic proxy for unknown Oblivious
-Request Resources. The proxy will only forward for Oblivious Request Resources
-that it has explicitly configured and allowed.
+This protocol assumes a fixed, one-to-one mapping between the Oblivious Proxy 
+Resource and the Oblivious Request Resource. This means that any encapsulated 
+request sent to the Oblivious Proxy Resource will always be forwarded to the 
+Oblivious Request Resource. This constraint was imposed to simplify proxy 
+configuration and mitigate against the Oblivious Proxy Resource being used as 
+a generic proxy for unknown Oblivious Request Resources. The proxy will only 
+forward for Oblivious Request Resources that it has explicitly configured and 
+allowed.
 
 It is possible for a server to be configured with multiple Oblivious
 Proxy Resources, each for a different Oblivious Request Resource as needed.

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1143,7 +1143,7 @@ the Oblivious Proxy Resource being used as a generic proxy for unknown Oblivious
 Request Resources. The proxy will only forward for Oblivious Request Resources
 that it has explicitly configured and allowed.
 
-It is possible for an Oblivious Proxy to be configured with multiple Oblivious
+It is possible for a server to be configured with multiple Oblivious
 Proxy Resources, each for a different Oblivious Request Resource as needed.
 As a consequence, the amount of state required for these mappings is linear
 in the number of Oblivious Proxy Resources supported.

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1145,8 +1145,6 @@ that it has explicitly configured and allowed.
 
 It is possible for a server to be configured with multiple Oblivious
 Proxy Resources, each for a different Oblivious Request Resource as needed.
-As a consequence, the amount of state required for these mappings is linear
-in the number of Oblivious Proxy Resources supported.
 
 
 ## Network Management

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1133,7 +1133,7 @@ to network topology.  A study of a similar system {{ODoH}} found that deploying
 proxies close to servers was most effective in minimizing additional latency.
 
 
-## Oblivious Proxy State {#proxy-state}
+## Resource Mappings {#proxy-state}
 
 The Oblivious Proxy Resource is a fixed mapping between URI and the Oblivious
 Request Resource. This means that any encapsulated request sent to the Oblivious


### PR DESCRIPTION
This makes the choice of a 1:1 mapping clear: avoid being used as an open proxy through explicit configuration of your ACLs.

Closes #77.
Closes #60.

cc @tfpauly 