### PR TITLE
Point in the direction of arbitrary forwarding

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1216,8 +1216,11 @@ a generic proxy for unknown Oblivious Request Resources. The proxy will only
 forward for Oblivious Request Resources that it has explicitly configured and
 allowed.
 
-It is possible for a server to be configured with multiple Oblivious
-Proxy Resources, each for a different Oblivious Request Resource as needed.
+It is possible for a server to be configured with multiple Oblivious Proxy
+Resources, each for a different Oblivious Request Resource as needed.  If the
+goal is to support a large number of Oblivious Request Resources, clients might
+be provided with a URI template {{?TEMPLATE=RFC6570}}, from which multiple
+Oblivious Proxy Resources could be constructed.
 
 
 ## Network Management


### PR DESCRIPTION
Truly, the most interesting forwarding is what occurs at the Oblivious
Request Resource, but this is a point of inflexibility that some people
struggle with.  No point in hiding how we might intend for a generic
proxy to operate.  The alternatives people invent are likely to be
worse if we don't at least point in the rough direction of a good
solution.

Closes #105.