### PR TITLE
Make clear that proxy metadata must be known to the client

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -998,7 +998,7 @@ information that a client is aware of.
 A proxy MAY add information to requests if the client is aware of the nature of
 the information that could be added.  The client does not need to be aware of
 the exact value added for each request, but needs to know the range of possible
-values the proxy might use.  Clients need to be aware any information added by
+values the proxy might use.  Clients need to be aware that any information added by
 the proxy can reduce the size of the anonymity set of clients at a server.
 
 A proxy can also generate responses, though it assumed to not be able to

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -979,11 +979,12 @@ information about the client, such as the Via field or the Forwarded field
 {{?FORWARDED=RFC7239}}.  A proxy MUST NOT add information when forwarding
 requests that might be used to identify clients, with the exception of
 information that a client is aware of.
-identity when forwarding requests without agreement from the client.  In
-particular, a proxy can attach additional information about a client to each
-request, provided this behavior is known to the client.  Clients need to be
-aware any additional bit of information added by the proxy can reduce the size
-of the client anonymity set behind the proxy by half.
+
+A proxy MAY add information to requests if the client is aware of the nature of
+the information that could be added.  The client does not need to be aware of
+the exact value added for each request, but needs to know the range of possible
+values the proxy might use.  Clients need to be aware any information added by
+the proxy can reduce the size of the anonymity set of clients at a server.
 
 A proxy can also generate responses, though it assumed to not be able to
 examine the content of a request (other than to observe the choice of key

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -662,7 +662,8 @@ The oblivious proxy resource interacts with the oblivious request resource as an
 HTTP client by constructing a request using the same restrictions as the client
 request, except that the target URI is the oblivious request resource.  The
 content of this request is copied from the client.  The oblivious proxy resource
-MUST NOT add information about the client to this request; see
+MUST NOT add information to the request without the client being aware of
+the type of information that might be added; see
 {{proxy-responsibilities}} for more information on proxy responsibilities.
 
 When a response is received from the oblivious request resource, the oblivious

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -647,7 +647,8 @@ The oblivious proxy resource interacts with the oblivious request resource by
 constructing a request using the same restrictions as the client request, except
 that the target URI is the oblivious request resource.  The content of this
 request is copied from the client.  The oblivious proxy resource MUST NOT add
-information about the client to this request.
+information about the client to this request without agreement from the client;
+see {{proxy-responsibilities}} for more information on proxy responsibilities.
 
 When a response is received from the oblivious request resource, the oblivious
 proxy resource forwards the response according to the rules of an HTTP proxy;
@@ -976,7 +977,11 @@ removing unknown fields removes this privacy risk.
 Secondly, generic implementations are often configured to augment requests with
 information about the client, such as the Via field or the Forwarded field
 {{?FORWARDED=RFC7239}}.  A proxy MUST NOT add information about the client
-identity when forwarding requests.
+identity when forwarding requests without agreement from the client.  In
+particular, a proxy can attach additional information about a client to each
+request, provided this behavior is known to the client.  Clients need to be
+aware any additional bit of information added by the proxy can reduce the size
+of the client anonymity set behind the proxy by half.
 
 A proxy can also generate responses, though it assumed to not be able to
 examine the content of a request (other than to observe the choice of key

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -999,7 +999,7 @@ information that a client is aware of.
 A proxy MAY add information to requests if the client is aware of the nature of
 the information that could be added.  The client does not need to be aware of
 the exact value added for each request, but needs to know the range of possible
-values the proxy might use.  Clients need to be aware that any information added by
+values the proxy might use.  It is important to note that information added by
 the proxy can reduce the size of the anonymity set of clients at a server.
 
 A proxy can also generate responses, though it assumed to not be able to

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -976,7 +976,9 @@ removing unknown fields removes this privacy risk.
 
 Secondly, generic implementations are often configured to augment requests with
 information about the client, such as the Via field or the Forwarded field
-{{?FORWARDED=RFC7239}}.  A proxy MUST NOT add information about the client
+{{?FORWARDED=RFC7239}}.  A proxy MUST NOT add information when forwarding
+requests that might be used to identify clients, with the exception of
+information that a client is aware of.
 identity when forwarding requests without agreement from the client.  In
 particular, a proxy can attach additional information about a client to each
 request, provided this behavior is known to the client.  Clients need to be


### PR DESCRIPTION
Split out from #96, since the shadowban bit needs more consideration in relation to target->proxy signals like rate limits.

Closes #100.

cc @ekr 