### PR TITLE
Client != HTTP client

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -257,6 +257,13 @@ map display).
 
 {::boilerplate bcp14}
 
+Client:
+
+: This document uses its own definition of client.  When referring to the HTTP
+  definition of client ({{Section 3.3 of HTTP}}), the term "HTTP client" is
+  used.  The Client role in this protocol acts as an HTTP client, but so does
+  the Oblivious Proxy Resource and the Oblivious Request Resource.
+
 Encapsulated Request:
 
 : An HTTP request that is encapsulated in an HPKE-encrypted message; see
@@ -643,11 +650,11 @@ about the content of the request, such as Alt-Used {{?ALT-SVC=RFC7838}}, or
 information that it trusts the oblivious proxy resource to remove, such as
 fields that are listed in the Connection header field.
 
-The oblivious proxy resource interacts with the oblivious request resource by
-constructing a request using the same restrictions as the client request, except
-that the target URI is the oblivious request resource.  The content of this
-request is copied from the client.  The oblivious proxy resource MUST NOT add
-information about the client to this request.
+The oblivious proxy resource interacts with the oblivious request resource as an
+HTTP client by constructing a request using the same restrictions as the client
+request, except that the target URI is the oblivious request resource.  The
+content of this request is copied from the client.  The oblivious proxy resource
+MUST NOT add information about the client to this request.
 
 When a response is received from the oblivious request resource, the oblivious
 proxy resource forwards the response according to the rules of an HTTP proxy;

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -261,8 +261,7 @@ Client:
 
 : This document uses its own definition of client.  When referring to the HTTP
   definition of client ({{Section 3.3 of HTTP}}), the term "HTTP client" is
-  used.  The Client role in this protocol acts as an HTTP client, but so does
-  the Oblivious Proxy Resource and the Oblivious Request Resource.
+  used; see {{http-usage}}.
 
 Encapsulated Request:
 
@@ -649,6 +648,15 @@ request content.  Clients MAY include fields that do not reveal information
 about the content of the request, such as Alt-Used {{?ALT-SVC=RFC7838}}, or
 information that it trusts the oblivious proxy resource to remove, such as
 fields that are listed in the Connection header field.
+
+The client role in this protocol acts as an HTTP client both with respect to the
+oblivious proxy resource and the oblivious target resource.  For the request the
+clients makes to the oblivious target resource, this diverges from typical HTTP
+assumptions about the use of a connection (see {{Section 3.3 of HTTP}}) in that
+the request and response are encapsulated rather than sent over a connection.
+The oblivious proxy resource and the oblivious request resource also act as HTTP
+clients toward the oblivious request resource and oblivious target resource
+respectively.
 
 The oblivious proxy resource interacts with the oblivious request resource as an
 HTTP client by constructing a request using the same restrictions as the client


### PR DESCRIPTION
It would be wrong to use "user agent" as this could be used for an HTTP
request made by any client toward any server (using the HTTP
definitions).

Closes #116.