### PR TITLE
Fixup some "request[s] of" language

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -705,7 +705,7 @@ Encapsulated Response.
 # Security Considerations {#security}
 
 In this design, a client wishes to make a request of a server that is
-authoritative for the Target Resource. The client wishes to make this request
+authoritative for a Target Resource. The client wishes to make this request
 without linking that request with either:
 
 1. The identity at the network and transport layer of the client (that is, the
@@ -1540,8 +1540,8 @@ corresponding public key as follows:
 ~~~
 
 This key configuration is somehow obtained by the client. Then when a client
-wishes to send an HTTP request of a GET request to the target `https://example.com`,
-it constructs the following binary HTTP message:
+wishes to send an HTTP GET request to the target `https://example.com`, it
+constructs the following binary HTTP message:
 
 ~~~ hex-dump
 00034745540568747470730b6578616d706c652e636f6d012f

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -657,6 +657,12 @@ When a response is received from the Oblivious Gateway Resource, the
 Oblivious Relay Resource forwards the response according to the rules of an
 HTTP proxy; see {{Section 7.6 of HTTP}}.
 
+An Oblivious Gateway Resource acts as a gateway for requests to the Target
+Resource (see {{Section 7.6 of HTTP}}).  The one exception is that any
+information it might forward in a response MUST be encapsulated, unless it is
+responding to errors it detects before removing encapsulation of the request;
+see {{errors}}.
+
 An Oblivious Gateway Resource, if it receives any response from the Target
 Resource, sends a single 200 response containing the encapsulated response.
 Like the request from the client, this response MUST only contain those fields
@@ -664,12 +670,6 @@ necessary to carry the encapsulated response: a 200 status code, a header field
 indicating the content type, and the encapsulated response as the response
 content.  As with requests, additional fields MAY be used to convey information
 that does not reveal information about the encapsulated response.
-
-An Oblivious Gateway Resource acts as a gateway for requests to the Target
-Resource (see {{Section 7.6 of HTTP}}).  The one exception is that any
-information it might forward in a response MUST be encapsulated, unless it is
-responding to errors it detects before removing encapsulation of the request;
-see {{errors}}.
 
 
 ## Informational Responses


### PR DESCRIPTION
Most of the text was correct in that we talk about making a request of a
resource.  Where the text refers to making requests of a server, those
usages seem to be correct.

Closes #156.