### PR TITLE
Clarify Gateway errors

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -691,7 +691,7 @@ response with an appropriate error status code (such as 400 (Bad Request) or
 {{Section 15.6.5 of HTTP}}, respectively), which is then encapsulated in the
 same way as a successful response.
 
-An Oblivious Gateway Resource which fails to decapsute as described in {{request}}
+An Oblivious Gateway Resource which fails to decapsulate as described in {{request}}
 because the Encapsulated Request key ID is invalid SHOULD send a 401 status code.
 Any other error that occurs prior to decapsulation SHOULD yield a response
 with a 400 status code. These errors are not encapsulated in the same way as

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -684,10 +684,18 @@ indicating the content type, and the encapsulated response as the response
 content.  As with requests, additional fields MAY be used to convey information
 that does not reveal information about the encapsulated response.
 
-An Oblivious Gateway Resource that does not receive a response can itself
-generate a response with an appropriate error status code (such as 504 (Gateway
-Timeout); see {{Section 15.6.5 of HTTP}}), which is then encapsulated in the
+An Oblivious Gateway Resource that fails to process the decapsulated request
+or does not receive a response from the Target Resource can itself generate a
+response with an appropriate error status code (such as 400 (Bad Request) or
+504 (Gateway Timeout); see {{Section 15.5.1 of HTTP}} and
+{{Section 15.6.5 of HTTP}}, respectively), which is then encapsulated in the
 same way as a successful response.
+
+An Oblivious Gateway Resource which fails to decapsute as described in {{request}}
+because the Encapsulated Request key ID is invalid SHOULD send a 401 status code.
+Any other error that occurs prior to decapsulation SHOULD yield a response
+with a 400 status code. These errors are not encapsulated in the same way as
+successful responses; see {{errors}}.
 
 In order to achieve the privacy and security goals of the protocol an Oblivious
 Gateway Resource also needs to observe the guidance in

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1553,7 +1553,7 @@ Registry name:  ohttp
 
 Specification:  [[THIS DOCUMENT]]
 
-Repository:  http://www.iana.org/assignments/dap
+Repository:  http://www.iana.org/assignments/ohttp
 
 Index value:  No transformation needed.
 ~~~


### PR DESCRIPTION
401 has proven useful as a signal that the client has an outdated configuration, so I think we ought to recommend it here. 