### PR TITLE
A scaled back version of the error signaling changes.

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -728,10 +728,11 @@ HTTP}} and {{Section 15.6.5 of HTTP}}, respectively).  This response
 encapsulated in the same way as a successful response.
 
 Errors in the encapsulation of requests mean that responses cannot be
-encapsulated.  The Oblivious Gateway Resource can generate and send a response
-with an error status to the Oblivious Relay Resource.  This response MAY be
-forwarded to the Client or treated by the Oblivious Relay Resource as a failure.
-If a Client receives a response that is not an Encapsulated Response, this could
+encapsulated.  This includes cases where the key configuration is incorrect or
+outdated.  The Oblivious Gateway Resource can generate and send a response with
+an error status to the Oblivious Relay Resource.  This response MAY be forwarded
+to the Client or treated by the Oblivious Relay Resource as a failure.  If a
+Client receives a response that is not an Encapsulated Response, this could
 indicate that the client configuration used to construct the request is
 incorrect or out of date.
 

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -724,7 +724,7 @@ Encapsulated Response.  This might be because the request is malformed or the
 Target Resource does not produce a response.  In either case the Oblivious
 Gateway Resource can generate a response with an appropriate error status code
 (such as 400 (Bad Request) or 504 (Gateway Timeout); see {{Section 15.5.1 of
-HTTP}} and {{Section 15.6.5 of HTTP}}, respectively).  This response
+HTTP}} and {{Section 15.6.5 of HTTP}}, respectively).  This response is
 encapsulated in the same way as a successful response.
 
 Errors in the encapsulation of requests mean that responses cannot be

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -676,13 +676,6 @@ information it might forward in a response MUST be encapsulated, unless it is
 responding to errors it detects before removing encapsulation of the request;
 see {{errors}}.
 
-An Oblivious Gateway Resource that successfully decapsulates a request but then
-encounters another error, e.g., because the request is malformed or the Target
-Resource does not produce a response, can itself generate a response with an
-appropriate error status code (such as 400 (Bad Request) or 504 (Gateway Timeout);
-see {{Section 15.5.1 of HTTP}} and {{Section 15.6.5 of HTTP}}, respectively).
-This response encapsulated in the same way as a successful response.
-
 An Oblivious Gateway Resource, if it receives any response from the Target
 Resource, sends a single 200 response containing the encapsulated response.
 Like the request from the client, this response MUST only contain those fields
@@ -727,8 +720,20 @@ without protection in response to the POST request made to that resource.
 
 Errors detected by the Oblivious Gateway Resource after successfully removing
 encapsulation and errors detected by the Target Resource MUST be sent in an
-Encapsulated Response.
+Encapsulated Response.  This might be because the request is malformed or the
+Target Resource does not produce a response.  In either case the Oblivious
+Gateway Resource can generate a response with an appropriate error status code
+(such as 400 (Bad Request) or 504 (Gateway Timeout); see {{Section 15.5.1 of
+HTTP}} and {{Section 15.6.5 of HTTP}}, respectively).  This response
+encapsulated in the same way as a successful response.
 
+Errors in the encapsulation of requests mean that responses cannot be
+encapsulated.  The Oblivious Gateway Resource can generate and send a response
+with an error status to the Oblivious Relay Resource.  This response MAY be
+forwarded to the Client or treated by the Oblivious Relay Resource as a failure.
+If a Client receives a response that is not an Encapsulated Response, this could
+indicate that the client configuration used to construct the request is
+incorrect or out of date.
 
 
 # Security Considerations {#security}

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -676,6 +676,13 @@ information it might forward in a response MUST be encapsulated, unless it is
 responding to errors it detects before removing encapsulation of the request;
 see {{errors}}.
 
+An Oblivious Gateway Resource that successfully decapsulates a request but then
+encounters another error, e.g., because the request is malformed or the Target
+Resource does not produce a response, can itself generate a response with an
+appropriate error status code (such as 400 (Bad Request) or 504 (Gateway Timeout);
+see {{Section 15.5.1 of HTTP}} and {{Section 15.6.5 of HTTP}}, respectively).
+This response encapsulated in the same way as a successful response.
+
 An Oblivious Gateway Resource, if it receives any response from the Target
 Resource, sends a single 200 response containing the encapsulated response.
 Like the request from the client, this response MUST only contain those fields


### PR DESCRIPTION
This starts by moving the good text from #187 to the "Errors" section, where I realized that it duplicated some of that language.  It was more complete, so I merged the two.

I then added some language about what happens to errors prior to decapsulation.  This doesn't define an error signaling format.  Though that might be useful, it is also a lot more work and I'm leery of scope creep in this document.

My view: if you get an error, you have screwed up somewhere.  You probably want to have a human look at what is going on.  The privacy consequences of automated responses are difficult to work out properly.  Hence this proposed change.

Closes #187.