### PR TITLE
Make the description of encapsulation clearer

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1272,8 +1272,8 @@ process, using new constant strings for the HPKE info and exporter
 context inputs.
 
 For example, a future specification might encapsulate DNS messages, which use
-the "application/dns-message" media type {{?RFC8484}}.  In the definition of a
-new, encrypted media type, the specification might define the use of string
+the "application/dns-message" media type {{?RFC8484}}.  In the definition of
+new, encrypted media types, specifications might define the use of string
 "application/dns-message request" (plus a zero byte and the header for the full
 value) for request encryption and the string "application/dns-message response"
 for response encryption.

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -628,6 +628,32 @@ Media types are used to identify Encapsulated Requests and Responses; see
 
 Evolution of the format of Encapsulated Requests and Responses is supported
 through the definition of new formats that are identified by new media types.
+New media types might be defined to use similar encapsulation with a different
+HTTP message format than in {{BINARY}}; see {{repurposing}} for guidance on
+reusing this encapsulation.  Alternatively, a new encapsulation method might be
+defined.
+
+
+## Repurposing the Encapsulation Format {#repurposing}
+
+The encrypted payload of an OHTTP request and response is a binary HTTP message
+{{BINARY}}.  The Client and Oblivious Gateway Resource agree on this encrypted
+payload type by specifying the media type "message/bhttp" in the HPKE info
+string and HPKE export context string for request and response encryption,
+respectively.
+
+Future specifications may repurpose the encapsulation mechanism described in
+this document.  This requires that the specification define a new media type.
+The encapsulation process for that content type can follow the same process,
+using new constant strings for the HPKE info and exporter context inputs.
+
+For example, a future specification might encapsulate DNS messages, which use
+the "application/dns-message" media type {{?RFC8484}}.  In creating a new,
+encrypted media types, specifications might define the use of string
+"application/dns-message request" (plus a zero byte and the header for the full
+value) for request encryption and the string "application/dns-message response"
+for response encryption.
+
 
 
 # HTTP Usage {#http-usage}
@@ -1258,27 +1284,6 @@ Oblivious HTTP has a simple key management design that is not trivially altered
 to enable interception by intermediaries.  Clients that are configured to enable
 interception might choose to disable Oblivious HTTP in order to ensure that
 content is accessible to middleboxes.
-
-
-# Repurposing the Encapsulation Format {#repurposing}
-
-The encrypted payload of an OHTTP request and response is a binary HTTP
-message {{BINARY}}. Client and target agree on this encrypted payload type by
-specifying the media type "message/bhttp" in the HPKE info string and HPKE
-export context string for request and response encryption, respectively.
-
-Future specifications may repurpose the encapsulation mechanism described in
-{{hpke-encapsulation}}.  This requires that the specification define a new media
-type.  The encapsulation process for that content type can follow the same
-process, using new constant strings for the HPKE info and exporter
-context inputs.
-
-For example, a future specification might encapsulate DNS messages, which use
-the "application/dns-message" media type {{?RFC8484}}.  In the definition of
-new, encrypted media types, specifications might define the use of string
-"application/dns-message request" (plus a zero byte and the header for the full
-value) for request encryption and the string "application/dns-message response"
-for response encryption.
 
 
 # IANA Considerations

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -412,9 +412,13 @@ new formats that are identified by new media types.
 
 HTTP message encapsulation uses HPKE for request and response encryption.
 
-By default, an encapsulated HTTP request contains a binary-encoded HTTP message
-{{BINARY}} and no other fields; see {{fig-req-pt}}.  This Encapsulated Request
-format is identified by the ["message/ohttp-req" media type](#iana-req).
+This document defines how a binary-encoded HTTP request {{BINARY}} is
+encapsulated.  This Encapsulated Request format is identified by the
+["`message/ohttp-req`" media type](#iana-req).  Alternative encapsulations or
+message formats are indicated using the media type.
+
+The content of "`message/ohttp-req`" request encapsulation contains only a
+binary HTTP message; see {{fig-req-pt}}.
 
 ~~~
 Request {
@@ -445,9 +449,13 @@ The Nenc parameter corresponding to the KEM used in HPKE can be found in
 {{Section 7.1 of !HPKE}}.  Nenc refers to the size of the encapsulated KEM
 shared secret, in bytes.
 
-An encrypted HTTP response includes a binary-encoded HTTP message {{BINARY}} and
-no other content; see {{fig-res-pt}}.  This Encapsulated Request format is
-identified by the ["message/ohttp-res" media type](#iana-res).
+This document defines how a binary-encoded HTTP request {{BINARY}} is
+encapsulated.  This Encapsulated Response format is identified by the
+["`message/ohttp-res`" media type](#iana-res).  Alternative encapsulations or
+message formats are indicated using the media type.
+
+The content of "`message/ohttp-res`" response encapsulation contains only a
+binary HTTP message; see {{fig-res-pt}}.
 
 ~~~
 Response {
@@ -495,7 +503,8 @@ encoded HTTP request, `request`, as follows:
    integers, respectively, each in network byte order.
 
 2. Build `info` by concatenating the ASCII-encoded string "message/bhttp
-   request", a zero byte, and the header.
+   request", a zero byte, and the header.  Note: {{repurposing}} discusses how
+   alternative message formats might use a different `info` value.
 
 3. Create a sending HPKE context by invoking `SetupBaseS()` ({{Section 5.1.1 of
    HPKE}}) with the public key of the receiver `pkR` and `info`.  This yields
@@ -573,6 +582,8 @@ follows:
 1. Export a secret `secret` from `context`, using the string "message/bhttp
    response" as context.  The length of this secret is `max(Nn, Nk)`, where `Nn`
    and `Nk` are the length of AEAD key and nonce associated with `context`.
+   Note: {{repurposing}} discusses how alternative message formats might use a
+   different `context` value.
 
 2. Generate a random value of length `max(Nn, Nk)` bytes, called
    `response_nonce`.
@@ -956,8 +967,9 @@ improve traffic analysis.
 
 Clients can use padding to reduce the effectiveness of traffic analysis.
 Padding is a capability provided by binary HTTP messages; see {{Section 3.8 of
-BINARY}}.  If the encapsulation format is used to protect a different message type
-(see {{repurposing}}), that message format might need to include padding support.
+BINARY}}.  If the encapsulation method described in this document is used to
+protect a different message type (see {{repurposing}}), that message format
+might need to include padding support.
 
 ## Server Responsibilities {#server-responsibilities}
 

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -655,7 +655,6 @@ value) for request encryption and the string "application/dns-message response"
 for response encryption.
 
 
-
 # HTTP Usage {#http-usage}
 
 A client interacts with the Oblivious Relay Resource by constructing an
@@ -957,7 +956,8 @@ improve traffic analysis.
 
 Clients can use padding to reduce the effectiveness of traffic analysis.
 Padding is a capability provided by binary HTTP messages; see {{Section 3.8 of
-BINARY}}.
+BINARY}}.  If the encapsulation format is used to protect a different message type
+(see {{repurposing}}), that message format might need to include padding support.
 
 ## Server Responsibilities {#server-responsibilities}
 

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -412,8 +412,9 @@ new formats that are identified by new media types.
 
 HTTP message encapsulation uses HPKE for request and response encryption.
 
-An encapsulated HTTP request contains a binary-encoded HTTP message {{BINARY}}
-and no other fields; see {{fig-req-pt}}.
+By default, an encapsulated HTTP request contains a binary-encoded HTTP message
+{{BINARY}} and no other fields; see {{fig-req-pt}}.  This Encapsulated Request
+format is identified by the ["message/ohttp-req" media type](#iana-req).
 
 ~~~
 Request {
@@ -444,8 +445,9 @@ The Nenc parameter corresponding to the KEM used in HPKE can be found in
 {{Section 7.1 of !HPKE}}.  Nenc refers to the size of the encapsulated KEM
 shared secret, in bytes.
 
-An encrypted HTTP response includes a binary-encoded HTTP message {{BINARY}}
-and no other content; see {{fig-res-pt}}.
+An encrypted HTTP response includes a binary-encoded HTTP message {{BINARY}} and
+no other content; see {{fig-res-pt}}.  This Encapsulated Request format is
+identified by the ["message/ohttp-res" media type](#iana-res).
 
 ~~~
 Response {

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -976,7 +976,7 @@ protocols that reuse this encryption format, especially new versions of this
 protocol, can ensure key diversity by choosing a different label in their use of
 HPKE.  The "message/bhttp response" label was chosen for symmetry only as it
 provides key diversity only within the HPKE context created using the
-"message/bhttp request" label; see {{repurposing-the-encapsulation-format}}.
+"message/bhttp request" label; see {{repurposing}}.
 
 
 ## Replay Attacks {#replay}
@@ -1258,7 +1258,7 @@ interception might choose to disable Oblivious HTTP in order to ensure that
 content is accessible to middleboxes.
 
 
-# Repurposing the Encapsulation Format
+# Repurposing the Encapsulation Format {#repurposing}
 
 The encrypted payload of an OHTTP request and response is a binary HTTP
 message {{BINARY}}. Client and target agree on this encrypted payload type by
@@ -1266,13 +1266,17 @@ specifying the media type "message/bhttp" in the HPKE info string and HPKE
 export context string for request and response encryption, respectively.
 
 Future specifications may repurpose the encapsulation mechanism described in
-{{hpke-encapsulation}}, provided that the content type of the encrypted
-payload is appropriately reflected in the HPKE info and context strings. For
-example, if a future specification were to use the encryption mechanism in
-this specification for DNS messages, identified by the "application/dns-message"
-media type, then the HPKE info string SHOULD be "application/dns-message
-request" for request encryption, and the HPKE export context string should be
-"application/dns-message response" for response encryption.
+{{hpke-encapsulation}}.  This requires that the specification define a new media
+type.  The encapsulation process for that content type can follow the same
+process, using new constant strings for the HPKE info and exporter
+context inputs.
+
+For example, a future specification might encapsulate DNS messages, which use
+the "application/dns-message" media type {{?RFC8484}}.  In the definition of a
+new, encrypted media type, the specification might define the use of string
+"application/dns-message request" (plus a zero byte and the header for the full
+value) for request encryption and the string "application/dns-message response"
+for response encryption.
 
 
 # IANA Considerations


### PR DESCRIPTION
This adds a little structure to the section on encapsulation and tries to make the relationship between different media types more distinct.

This builds on top of #191 (which we are going to merge soon) because that hits all the same text and we have already effectively agreed to those changes.

You can review [a single commit](https://github.com/ietf-wg-ohai/oblivious-http/commit/3373bce07660b762050ba34c6051ac8dd86048cd) to see what the substance of these changes are.  Alternatively, just look at the top of the "HPKE Encapsulation" section (the other changes are unrelated).