### PR TITLE
More on unsecured requests

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1059,10 +1059,14 @@ If separate entities provide the Oblivious Gateway Resource and Target Resource,
 these entities might need an arrangement similar to that between server and
 relay for managing denial of service; see {{dos}}.
 
-Nonsecure requests - such as those with the "http" scheme as opposed to the "https"
-scheme - SHOULD NOT be used if the Oblivious Gateway and Target Resources are
-operated by different entities as that would expose both requests and response
-to modification or inspection by a network attacker.
+Nonsecure requests - such as those with the "http" scheme as opposed to the
+"https" scheme - SHOULD NOT be used if the Oblivious Gateway and Target
+Resources are not on the same origin.  If messages are forwarded between these
+resources without the protections afforded by HTTPS, they could be inspected or
+modified by a network attacker.  Insisting that the two resources share an
+origin does not guarantee that requests are not forwarded without protection, so
+clients might need to use other means of ensuring that unsecured requests are
+not exposed to attack.
 
 
 ## Key Management

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1063,10 +1063,8 @@ Nonsecure requests - such as those with the "http" scheme as opposed to the
 "https" scheme - SHOULD NOT be used if the Oblivious Gateway and Target
 Resources are not on the same origin.  If messages are forwarded between these
 resources without the protections afforded by HTTPS, they could be inspected or
-modified by a network attacker.  Insisting that the two resources share an
-origin does not guarantee that requests are not forwarded without protection, so
-clients might need to use other means of ensuring that unsecured requests are
-not exposed to attack.
+modified by a network attacker.  Note that two resources that share an
+origin do not guarantee that requests are not forwarded without protection.
 
 
 ## Key Management


### PR DESCRIPTION
As @squarooticus observes in his review, "same entity" is more or less meaningless when it comes to ensuring that forwarding doesn't happen in the clear.  This narrows the recommendation to a concrete "same origin", but notes that even that is not sufficient in all cases.