### PR TITLE
A relay can pad too

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1101,8 +1101,8 @@ HTTP messages; see {{Section 3.8 of BINARY}}.  If the encapsulation method
 described in this document is used to protect a different message type (see
 {{repurposing}}), that message format might need to include padding support.
 Oblivious Relay Resources can also use padding for the same reason, but need to
-operate at the HTTP layer; for example, see {{Section 10.7 of HTTP2}} or
-{{Section 10.7 of HTTP3}}).
+operate at the HTTP layer since they cannot manipulate binary HTTP messages; for example,
+see {{Section 10.7 of HTTP2}} or {{Section 10.7 of HTTP3}}).
 
 
 ## Server Responsibilities {#server-responsibilities}

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1100,6 +1100,9 @@ effectiveness of traffic analysis.  Padding is a capability provided by binary
 HTTP messages; see {{Section 3.8 of BINARY}}.  If the encapsulation method
 described in this document is used to protect a different message type (see
 {{repurposing}}), that message format might need to include padding support.
+Oblivious Relay Resources can also use padding for the same reason, but need to
+operate at the HTTP layer; for example, see {{Section 10.7 of HTTP2}} or
+{{Section 10.7 of HTTP3}}).
 
 
 ## Server Responsibilities {#server-responsibilities}


### PR DESCRIPTION
This came out of #257, where we realized that the relay padding is useful, but needs to employ different methods than client or gateway. The relay can't use binary HTTP padding; it has to insert stuff at the HTTP layer.  Include citations for padding in those documents.

Note that these citations are slightly misleading.  Most relays won't have access at the level necessary to add that padding.  More likely, the relay will need to do as @chris-wood originally suggested, namely adding fields of an appropriate size.  But we don't have good citations for that, so I'm cheaping out.  (Note that RFC 9112, Section 7.1.1 talks about using chunk extensions for padding, but I'm going to pretend that doesn't exist; it's even less usable than the HTTP/2 and HTTP/3 options.)