### PR TITLE
Separate target and gateway

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1140,7 +1140,9 @@ A Target Resource that is operated on a different server from the Oblivious
 Gateway Resource is an ordinary HTTP resource.  A Target Resource can privilege
 requests that are forwarded by a given Oblivious Gateway Resource if it trusts
 the operator of the Oblivious Gateway Resource to only forward requests that
-meet the expectations of the Target Resource.
+meet the expectations of the Target Resource.  Otherwise, the Target Resource
+treats requests from an Oblivious Gateway Resource no differently than any
+other HTTP client.
 
 For instance, an Oblivious Gateway Resource might -- possibly with the help of
 Oblivious Relay Resources -- be trusted not to forward an excessive volume of

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1134,6 +1134,24 @@ modified by a network attacker.  Note that a request could be forwarded without
 protection if the two resources share an origin.
 
 
+## Separate Gateway and Target
+
+A Target Resource that is operated on a different server from the Oblivious
+Gateway Resource is an ordinary HTTP resource.  A Target Resource can privilege
+requests that are forwarded by a given Oblivious Gateway Resource if it trusts
+the operator of the Oblivious Gateway Resource to only forward requests that
+meet the expectations of the Target Resource.
+
+For instance, an Oblivious Gateway Resource might -- possibly with the help of
+the Oblivious Relay Resource -- be trusted not to forward an excessive volume of
+requests, which might allow the Target Resource to accept a greater volume of
+requests from that Oblivious Gateway Resource relative to other HTTP clients.
+
+An Oblivious Gateway Resource could implement policies that improve the ability
+of the Target Resource to implement policy exemptions, such as only forwarding
+requests toward specific Target Resources.
+
+
 ## Key Management
 
 An Oblivious Gateway Resource needs to have a plan for replacing keys. This

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1143,8 +1143,8 @@ the operator of the Oblivious Gateway Resource to only forward requests that
 meet the expectations of the Target Resource.
 
 For instance, an Oblivious Gateway Resource might -- possibly with the help of
-the Oblivious Relay Resource -- be trusted not to forward an excessive volume of
-requests, which might allow the Target Resource to accept a greater volume of
+Oblivious Relay Resources -- be trusted not to forward an excessive volume of
+requests. This might allow the Target Resource to accept a greater volume of
 requests from that Oblivious Gateway Resource relative to other HTTP clients.
 
 An Oblivious Gateway Resource could implement policies that improve the ability

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -248,14 +248,14 @@ steps occur to return this response to the client:
 3. The Client removes the encapsulation to obtain the response to the original
     request.
 
-This interaction provides authentication and confidentiality protection between the
-Client and the Oblivious Gateway, but importantly not between the Client and the
-Target Resource. While the Target Resource is a distinct HTTP resource from the
-Oblivious Gateway Resource, they are both logically under the control of the Oblivious
-Gateway, since the Oblivious Gateway Resource can unilaterally dictate the responses
-returned from the Target Resource to the Client. This arrangement is shown in {{fig-overview}}.
-See {{security}} for more information about Client and Oblivious Relay, and Oblivous Gateway
-resources in running this protocol.
+This interaction provides authentication and confidentiality protection between
+the Client and the Oblivious Gateway, but importantly not between the Client and
+the Target Resource. While the Target Resource is a distinct HTTP resource from
+the Oblivious Gateway Resource, they are both logically under the control of the
+Oblivious Gateway, since the Oblivious Gateway Resource can unilaterally dictate
+the responses returned from the Target Resource to the Client. This arrangement
+is shown in {{fig-overview}}.
+
 
 ## Applicability
 
@@ -305,6 +305,9 @@ something about that user even if the identity of the user is pseudonymous.
 Other examples include the submission of anonymous surveys, making search
 queries, or requesting location-specific content (such as retrieving tiles of a
 map display).
+
+In addition to these limitations, {{security}} describes operational constraints
+that are necessary to realize the goals of the protocol.
 
 
 ## Conventions and Definitions

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1441,7 +1441,7 @@ requests from that Oblivious Gateway Resource relative to other HTTP clients.
 
 An Oblivious Gateway Resource could implement policies that improve the ability
 of the Target Resource to implement policy exemptions, such as only forwarding
-requests toward specific Target Resources.
+requests toward specific Target Resources according to an allowlist; see {{server-responsibilities}}.
 
 
 # Privacy Considerations {#privacy}

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1134,26 +1134,6 @@ modified by a network attacker.  Note that a request could be forwarded without
 protection if the two resources share an origin.
 
 
-## Separate Gateway and Target
-
-A Target Resource that is operated on a different server from the Oblivious
-Gateway Resource is an ordinary HTTP resource.  A Target Resource can privilege
-requests that are forwarded by a given Oblivious Gateway Resource if it trusts
-the operator of the Oblivious Gateway Resource to only forward requests that
-meet the expectations of the Target Resource.  Otherwise, the Target Resource
-treats requests from an Oblivious Gateway Resource no differently than any
-other HTTP client.
-
-For instance, an Oblivious Gateway Resource might -- possibly with the help of
-Oblivious Relay Resources -- be trusted not to forward an excessive volume of
-requests. This might allow the Target Resource to accept a greater volume of
-requests from that Oblivious Gateway Resource relative to other HTTP clients.
-
-An Oblivious Gateway Resource could implement policies that improve the ability
-of the Target Resource to implement policy exemptions, such as only forwarding
-requests toward specific Target Resources.
-
-
 ## Key Management
 
 An Oblivious Gateway Resource needs to have a plan for replacing keys. This
@@ -1399,6 +1379,26 @@ resource - defines how content is processed; see {{Section 3.1 of HTTP}}.  HTTP
 clients can also use resource identity and response content to determine how
 content is processed.  Consequently, the security considerations of {{Section 17
 of HTTP}} also apply to the handling of the content of these media types.
+
+
+## Separate Gateway and Target
+
+A Target Resource that is operated on a different server from the Oblivious
+Gateway Resource is an ordinary HTTP resource.  A Target Resource can privilege
+requests that are forwarded by a given Oblivious Gateway Resource if it trusts
+the operator of the Oblivious Gateway Resource to only forward requests that
+meet the expectations of the Target Resource.  Otherwise, the Target Resource
+treats requests from an Oblivious Gateway Resource no differently than any
+other HTTP client.
+
+For instance, an Oblivious Gateway Resource might -- possibly with the help of
+Oblivious Relay Resources -- be trusted not to forward an excessive volume of
+requests. This might allow the Target Resource to accept a greater volume of
+requests from that Oblivious Gateway Resource relative to other HTTP clients.
+
+An Oblivious Gateway Resource could implement policies that improve the ability
+of the Target Resource to implement policy exemptions, such as only forwarding
+requests toward specific Target Resources.
 
 
 # Privacy Considerations {#privacy}

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -910,12 +910,12 @@ In this section, a deployment where there are three entities is considered:
 * A relay operates the Oblivious Relay Resource
 * A server operates both the Oblivious Gateway Resource and the Target Resource
 
+{{separate-target}} discusses the security implications for a case where
+different servers operate the Oblivious Gateway Resource and Target Resource.
+
 Requests from the Client to Oblivious Relay Resource and from Oblivious Relay
 Resource to Oblivious Gateway Resource MUST use HTTPS in order to provide
-unlinkability in the presence of a network observer.  The scheme of the
-Encapsulated Request determines what is used between the Oblivious Gateway and
-Target Resources, though using HTTPS is RECOMMENDED; see
-{{server-responsibilities}}.
+unlinkability in the presence of a network observer.
 
 To achieve the stated privacy goals, the Oblivious Relay Resource cannot be
 operated by the same entity as the Oblivious Gateway Resource. However,
@@ -1381,7 +1381,16 @@ content is processed.  Consequently, the security considerations of {{Section 17
 of HTTP}} also apply to the handling of the content of these media types.
 
 
-## Separate Gateway and Target
+## Separate Gateway and Target {#separate-target}
+
+This document generally assumes that the same entity operates the Oblivious
+Gateway Resource and the Target Resource.  However, as the Oblivious Gateway
+Resource performs generic HTTP processing, the use of forwarding cannot be
+completely precluded.
+
+The scheme specified in the Encapsulated Request determines the security
+requirements for any protocol that is used between the Oblivious Gateway and
+Target Resources.  Using HTTPS is RECOMMENDED; see {{server-responsibilities}}.
 
 A Target Resource that is operated on a different server from the Oblivious
 Gateway Resource is an ordinary HTTP resource.  A Target Resource can privilege


### PR DESCRIPTION
This talks about the odd case where target and gateway are separate. The primary insight here is that the target is just a regular HTTP resource and the requests from the gateway aren't special.  Problems only occur if the gateway is privileged in some way.

If abuse comes via the gateway, then the target would ordinary block the client, which tends to affect a bunch of bystanders in this model.  So there is pressure to do something special for the gateway.  In that case, the target is trusting the gateway in some way.  Explain that.

The heading here is the only case where we use the short names of the entities, but I can't stand short headings.