### PR TITLE
OHTTP is a protocol between client, relay, gateway

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -186,11 +186,12 @@ does the Oblivious Gateway Resource learn which of the requests it receives are
 from the same Client.
 
 ~~~ aasvg
-+---------+       +----------+      +----------+      +----------+
-| Client  |       | Relay    |      | Gateway  |      | Target   |
-|         |       | Resource |      | Resource |      | Resource |
-+----+----+       +----+-----+      +-------+--+      +----+-----+
-     |                 |                    |              |
+                                  /--------------------------------`
++---------+       +----------+   |  +----------+      +----------+  |
+| Client  |       | Relay    |   |  | Gateway  |      | Target   |  |
+|         |       | Resource |   |  | Resource |      | Resource |  |
++----+----+       +----+-----+   |  +-------+--+      +----+-----+  |
+     |                 |          `---------|--------------|-------'
      | Relay           |                    |              |
      | Request         |                    |              |
      | [+ Encapsulated |                    |              |
@@ -246,6 +247,15 @@ steps occur to return this response to the client:
 
 3. The Client removes the encapsulation to obtain the response to the original
     request.
+
+This interaction provides authentication and confidentiality protection between the
+Client and the Oblivious Gateway, but importantly not between the Client and the
+Target Resource. While the Target Resource is a distinct HTTP resource from the
+Oblivious Gateway Resource, they are both logically under the control of the Oblivious
+Gateway, since the Oblivious Gateway Resource can unilaterally dictate the responses
+returned from the Target Resource to the Client. This arrangement is shown in {{fig-overview}}.
+See {{security}} for more information about Client and Oblivious Relay, and Oblivous Gateway
+resources in running this protocol.
 
 ## Applicability
 
@@ -902,9 +912,9 @@ been encapsulated.
 
 # Security Considerations {#security}
 
-In this design, a Client wishes to make a request of a server that is
-authoritative for a Target Resource. The Client wishes to make this request
-without linking that request with either:
+In this design, a Client wishes to make a request to an Oblivious Gateway Resource
+that is forwarded to a Target Resource. The Client wishes to make this request without
+linking that request with either:
 
 1. The identity at the network and transport layer of the Client (that is, the
    Client IP address and TCP or UDP port number the Client uses to create a
@@ -939,17 +949,15 @@ interactions between those resources without affecting Client privacy.
 As a consequence of this configuration, Oblivious HTTP prevents linkability
 described above. Informally, this means:
 
-1. Requests and responses are known only to Clients and Target Resources, plus
-   Oblivious Gateway Resources that possess the corresponding response
-   encapsulation key and HPKE keying material.  In particular, the Oblivious
-   Relay Resource knows the origin and destination of an Encapsulated Request and
-   Response, yet does not know the decrypted contents. Likewise, Oblivious
-   Gateway Resources learn only the Oblivious Relay Resource and the decrypted
-   request.  No entity other than the Client can see the plaintext request and
-   response and can attribute them to the Client.
+1. Requests and responses are known only to Clients and Oblivious Gateway Resources.
+   In particular, the Oblivious Relay Resource knows the origin and destination
+   of an Encapsulated Request and Response, yet does not know the decrypted contents.
+   Likewise, Oblivious Gateway Resources learn only the Oblivious Relay Resource and
+   the decrypted request.  No entity other than the Client can see the plaintext
+   request and response and can attribute them to the Client.
 
-2. Targets cannot link requests from the same Client in the absence of unique
-   per-Client keys.
+2. Oblivous Gateway Resources, and therefore Target Resources, cannot link requests
+   from the same Client in the absence of unique per-Client keys.
 
 Traffic analysis that might affect these properties are outside the scope of
 this document; see {{ta}}.
@@ -958,6 +966,12 @@ A formal analysis of Oblivious HTTP is in {{OHTTP-ANALYSIS}}.
 
 
 ## Client Responsibilities {#sec-client}
+
+Clients MUST maintain an explicit allowlist of target resources that the client trusts
+an Oblivious Gateway to respond for, and check requests against this allowlist before
+sending them. This ensures that Oblivious Gateway Resources are not abused to forward
+traffic to arbitrary Target Resources. See {{server-responsibilities}} for
+similar responsibilities that apply to Oblivious Gateway Resources.
 
 Clients MUST ensure that the key configuration they select for generating
 Encapsulated Requests is integrity protected and authenticated so that it can

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -231,8 +231,7 @@ Resource, the following steps occur, as shown in {{fig-overview}}:
    the HPKE protection to obtain an HTTP request.
 
 The Oblivious Gateway Resource then handles the HTTP request. This typically
-involves making an HTTP request that includes the target URI, method, fields,
-and content of the request acquired from the Encapsulated Request. Once the
+involves making an HTTP request using the content of the Encapsulated Request. Once the
 Oblivious Gateway Resource has an HTTP response for this request, the following
 steps occur to return this response to the client:
 

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -147,6 +147,7 @@ service. In particular, the protocol in this document describes:
 
 3. requirements for how the Oblivious Gateway Resource handles encapsulated HTTP
    messages and produces encapsulated responses for the client.
+
 The combination of encapsulation and relaying ensures that Oblivious Gateway Resource
 never sees the client's IP address and the Oblivious Relay Resource never sees
 plaintext HTTP message content.

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -152,7 +152,7 @@ never sees the client's IP address and the Oblivious Relay Resource never sees
 plaintext HTTP message content.
 
 Oblivious HTTP allows connection reuse between the client and Oblivious Relay
-Resource, as well as between that relay and the Oblivious Gateway Resource, this
+Resource, as well as between that relay and the Oblivious Gateway Resource, so this
 scheme represents a performance improvement over using just one request in each
 connection.  With limited trust placed in the Oblivious Relay Resource (see
 {{security}}), Clients are assured that requests are not uniquely attributed to

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -136,7 +136,7 @@ additional CPU cost of cryptographic computations.
 
 To overcome these limitations, this document defines Oblivious HTTP, a protocol for
 encrypting and sending HTTP messages from a client to a gateway through a trusted relay
-service. In particular, the protocol in this document describes: 
+service. In particular, the protocol in this document describes:
 
 1. an algorithm for encapsulating binary HTTP messages {{BINARY}} using Hybrid
    Public Key Encryption (HPKE; {{HPKE}}) to protect their contents,

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -136,12 +136,17 @@ additional CPU cost of cryptographic computations.
 
 To overcome these limitations, this document defines Oblivious HTTP, a protocol for
 encrypting and sending HTTP messages from a client to a gateway through a trusted relay
-service. In particular, the protocol in this document describes: (1) an algorithm for
-encapsulating binary HTTP messages {{BINARY}} using Hybrid Public Key Encryption (HPKE;
-{{HPKE}}) to protect their contents, (2) a method for forwarding these encapsulated
-messages between clients and an Oblivious Gateway Resource through a trusted Oblivious
-Relay Resource using HTTP, and (3) requirements for how the Oblivious Gateway Resource
-handles encapsulated HTTP messages and produces encapsulated responses for the client.
+service. In particular, the protocol in this document describes: 
+
+1. an algorithm for encapsulating binary HTTP messages {{BINARY}} using Hybrid
+   Public Key Encryption (HPKE; {{HPKE}}) to protect their contents,
+
+2. a method for forwarding these encapsulated messages between clients and an
+   Oblivious Gateway Resource through a trusted Oblivious Relay Resource using
+   HTTP, and
+
+3. requirements for how the Oblivious Gateway Resource handles encapsulated HTTP
+   messages and produces encapsulated responses for the client.
 The combination of encapsulation and relaying ensures that Oblivious Gateway Resource
 never sees the client's IP address and the Oblivious Relay Resource never sees
 plaintext HTTP message content.

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -1139,7 +1139,7 @@ If separate entities provide the Oblivious Gateway Resource and Target Resource,
 these entities might need an arrangement similar to that between server and
 relay for managing denial of service; see {{dos}}. Moreover, the Oblivious Gateway
 Resource SHOULD apply some form of allowlist to ensure that the Oblivious Gateway
-Resource is not misused as a relay for HTTP messages to arbitrary Target Resources.
+Resource is not misused as a relay for HTTP messages to an arbitrary Target Resource.
 
 Non-secure requests - such as those with the "http" scheme as opposed to the
 "https" scheme - SHOULD NOT be used if the Oblivious Gateway and Target

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -967,7 +967,8 @@ A formal analysis of Oblivious HTTP is in {{OHTTP-ANALYSIS}}.
 
 ## Client Responsibilities {#sec-client}
 
-Clients MUST maintain an explicit allowlist of target resources that the client trusts
+Because Clients do not authenticate the Target Resource when using Oblivious HTTP,
+Clients MUST maintain an explicit allowlist of target resources that the Client trusts
 an Oblivious Gateway to respond for, and check requests against this allowlist before
 sending them. This ensures that Oblivious Gateway Resources are not abused to forward
 traffic to arbitrary Target Resources. See {{server-responsibilities}} for

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -186,7 +186,7 @@ does the Oblivious Gateway Resource learn which of the requests it receives are
 from the same Client.
 
 ~~~ aasvg
-                                  /--------------------------------`
+                                  .--------------------------------.
 +---------+       +----------+   |  +----------+      +----------+  |
 | Client  |       | Relay    |   |  | Gateway  |      | Target   |  |
 |         |       | Resource |   |  | Resource |      | Resource |  |

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -177,10 +177,12 @@ An Oblivious HTTP Client must initially know the following:
   uses a one-to-one mapping between Oblivious Relay and Gateway Resources; see
   {{proxy-state}} for more details.
 
-This information allows the Client to forward a request for some Target Resource
-to the Oblivious Gateway Resource without the Oblivious Gateway Resource learning the
-client's IP address or any other identifying information that might be revealed from
-the client at the transport layer.
+This information allows the Client to send HTTP requests to the Oblivious
+Gateway Resource for forwarding to a Target Resource.  The Oblivious Gateway
+Resource does not learn the client's IP address or any other identifying
+information that might be revealed from the client at the transport layer, nor
+does the Oblivious Gateway Resource learn which of the requests it receives are
+from the same Client.
 
 ~~~ aasvg
 +---------+       +----------+      +----------+      +----------+


### PR DESCRIPTION
This change tries to emphasize that OHTTP is a protocol between client, relay, and gateway, and that the target is sort of ancillary to the whole thing. It further clarifies that the relay should not act as an open proxy when it's operated by an entity that is separate from the target server.

