### PR TITLE
Length prefix key encoding when there are multiple

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -491,6 +491,11 @@ of the media type.
 Evolution of the key configuration format is supported through the definition of
 new formats that are identified by new media types.
 
+A Client that receives an "application/ohttp-keys" object with encoding errors
+might be able to recover one or more key configurations.  Differences in how key
+configurations are recovered might be exploited to segregate Clients, so Clients
+MUST discard invalid objects.
+
 
 # HPKE Encapsulation
 

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -494,7 +494,7 @@ new formats that are identified by new media types.
 A Client that receives an "application/ohttp-keys" object with encoding errors
 might be able to recover one or more key configurations.  Differences in how key
 configurations are recovered might be exploited to segregate Clients, so Clients
-MUST discard invalid objects.
+MUST discard incorrectly encoded key configuration collections.
 
 
 # HPKE Encapsulation

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -482,8 +482,11 @@ HPKE Symmetric Algorithms:
 
 The "application/ohttp-keys" format is a media type that identifies a serialized
 collection of key configurations. The content of this media type comprises one
-or more key configuration encodings (see {{key-config}}) that are concatenated;
-see {{iana-keys}} for a definition of the media type.
+or more key configuration encodings (see {{key-config}}).  Each encoded
+configuration is prefixed with a two byte integer in network byte order that
+indicates the length of the key configuration in bytes.  The length-prefixed
+encodings are concatenated.  See {{iana-keys}} for a definition of the media
+type.
 
 Evolution of the key configuration format is supported through the definition of
 new formats that are identified by new media types.

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -485,7 +485,7 @@ collection of key configurations. The content of this media type comprises one
 or more key configuration encodings (see {{key-config}}).  Each encoded
 configuration is prefixed with a two byte integer in network byte order that
 indicates the length of the key configuration in bytes.  The length-prefixed
-encodings are concatenated.  See {{iana-keys}} for a definition of the media
+encodings are concatenated to form a list.  See {{iana-keys}} for a definition of the media
 type.
 
 Evolution of the key configuration format is supported through the definition of

--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -485,8 +485,8 @@ collection of key configurations. The content of this media type comprises one
 or more key configuration encodings (see {{key-config}}).  Each encoded
 configuration is prefixed with a two byte integer in network byte order that
 indicates the length of the key configuration in bytes.  The length-prefixed
-encodings are concatenated to form a list.  See {{iana-keys}} for a definition of the media
-type.
+encodings are concatenated to form a list.  See {{iana-keys}} for a definition
+of the media type.
 
 Evolution of the key configuration format is supported through the definition of
 new formats that are identified by new media types.


### PR DESCRIPTION
This changes the definition of "application/ohttp-keys" in a way that is not backwards compatible, but it ensures that the format is usable once new KEMs are introduced.